### PR TITLE
Use state for speech recognition support detection

### DIFF
--- a/src/hooks/useSpeechRecognition.js
+++ b/src/hooks/useSpeechRecognition.js
@@ -8,16 +8,16 @@ export const useSpeechRecognition = (config = {}) => {
   const [error, setError] = useState(null);
 
   const recognitionRef = useRef(null);
-  const isSupported = useRef(false);
+  const [isSupported, setIsSupported] = useState(false);
 
   // Check for browser support
   useEffect(() => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (SpeechRecognition) {
-      isSupported.current = true;
+      setIsSupported(true);
       recognitionRef.current = new SpeechRecognition();
     } else {
-      isSupported.current = false;
+      setIsSupported(false);
       setError('Speech recognition is not supported in this browser');
     }
   }, []);
@@ -105,7 +105,7 @@ export const useSpeechRecognition = (config = {}) => {
   }, [config]);
 
   const startListening = useCallback(() => {
-    if (!recognitionRef.current || !isSupported.current) {
+    if (!recognitionRef.current || !isSupported) {
       setError('Speech recognition is not available');
       return;
     }
@@ -117,7 +117,7 @@ export const useSpeechRecognition = (config = {}) => {
       setError('Failed to start speech recognition');
       console.error('Speech recognition start error:', err);
     }
-  }, []);
+  }, [isSupported]);
 
   const stopListening = useCallback(() => {
     if (recognitionRef.current && isListening) {
@@ -141,6 +141,6 @@ export const useSpeechRecognition = (config = {}) => {
     startListening,
     stopListening,
     resetTranscript,
-    isSupported: isSupported.current
+    isSupported
   };
 };


### PR DESCRIPTION
## Summary
- replace the speech recognition support ref with state updates when checking browser capabilities
- ensure startListening uses the stateful support flag while keeping recognition setup intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20d06ce6883298617fe876b6c3e35