### PR TITLE
Handle speech recognition errors without duplicate messaging

### DIFF
--- a/src/components/PracticeSession.tsx
+++ b/src/components/PracticeSession.tsx
@@ -217,12 +217,15 @@ export const PracticeSession: React.FC<PracticeSessionProps> = ({
       // Wait a moment for speech recognition to finish processing
       await new Promise(resolve => setTimeout(resolve, 1000));
 
-      let finalTranscript = transcript.trim() || interimTranscript.trim();
+      const finalTranscript = transcript.trim() || interimTranscript.trim();
 
       // Since Gemini doesn't have audio transcription, rely on browser speech recognition
       if (!finalTranscript) {
+        if (speechError) {
+          setError(null);
+          return;
+        }
         setError('No speech detected. Please try speaking again or ensure your microphone is working.');
-        setIsProcessing(false);
         return;
       }
 
@@ -242,6 +245,7 @@ export const PracticeSession: React.FC<PracticeSessionProps> = ({
     speechSupported,
     transcript,
     interimTranscript,
+    speechError,
     clearRecording,
     resetTranscript
   ]);


### PR DESCRIPTION
## Summary
- avoid overwriting speech recognition errors when no transcript is produced
- ensure the stop-recording handler reacts to hook errors by exiting early and keeping UI alerts accurate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21a3fca108329a91a5c4ea1ac9f95